### PR TITLE
feat: ensure DashScope transformer sets event stream content type

### DIFF
--- a/__tests__/claude-code-router-config.test.js
+++ b/__tests__/claude-code-router-config.test.js
@@ -254,6 +254,7 @@ describe("ClaudeCodeRouterConfig", () => {
       expect(content).toContain("class DashScopeTransformer");
       expect(content).toContain('name = "dashscope"');
       expect(content).toContain("transformRequestIn");
+      expect(content).toContain("transformResponseOut");
       expect(content).toContain("module.exports = DashScopeTransformer");
     });
   });

--- a/bin/claude-code-router-config.js
+++ b/bin/claude-code-router-config.js
@@ -273,6 +273,17 @@ class ClaudeCodeRouterConfig {
     request.stream = this.stream;
     return request;
   }
+
+  async transformResponseOut(response) {
+    const contentType = response.headers.get("Content-Type");
+    const isEventStream = contentType?.includes("text/event-stream");
+
+    if (!isEventStream) {
+      response.headers.set("Content-Type", "text/event-stream");
+    }
+
+    return response;
+  }
 }
 
 module.exports = DashScopeTransformer;`;


### PR DESCRIPTION
## Summary
- ensure DashScope transformer sets Content-Type to text/event-stream when needed
- cover new transformResponseOut in template test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68930a692ec08320ba2b944999ffeeb7